### PR TITLE
Fix Spinner Hiding

### DIFF
--- a/assets/js/options.js
+++ b/assets/js/options.js
@@ -31,10 +31,10 @@ $(document).ready(function() {
         settings.enabled = feature in items ? items[feature].enabled : sections[section][feature].default;
         addSettingOptionToList(section, feature, settings);
       }
-
-      $("#spinner").hide();
-      $("#main").show();
     }
+
+    $("#main").show();
+    $("#spinner").hide();
 
     createChangeHandlers();
   });


### PR DESCRIPTION
Moved option spinner hiding to correct spot. Not really a noticeable issue since it gets the settings and constructs the HTML so quickly. Introduced by #43.