### PR TITLE
Feature/update templates rendering newlines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.js eol=crlf

--- a/templates/CRLFWriter.js
+++ b/templates/CRLFWriter.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+module.exports = (filename, content) => {
+  let dir = path.dirname(filename);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  fs.writeFileSync(filename, content.replace(/\r\n|[\r\n]/g, "\r\n"));
+};

--- a/templates/Configurables.js
+++ b/templates/Configurables.js
@@ -1,34 +1,34 @@
-const fs = require("fs");
 const globby = require("globby");
 const mustache = require("mustache");
+const writer = require("./CRLFWriter");
 
-const template = `module.exports = {\r
-  {{ #configurables }}\r
-  {{{ name }}}: require("./configurables/{{{ name }}}"){{ #next }},{{ /next }}\r
-  {{ /configurables }}\r
-};\r
+const template = `module.exports = {
+  {{ #configurables }}
+  {{{ name }}}: require("./configurables/{{{ name }}}"){{ #next }},{{ /next }}
+  {{ /configurables }}
+};
 `;
 
 mustache.parse(template);
 
-const configurables = globby.sync("./src/configurables/*.js").map(configurable => {
-  return {
-    name: configurable.split("/").pop().split(".js").shift(),
-    next: true
-  };
-}).sort((f1, f2) => {
-  if (f1.name < f2.name) {
-    return -1;
-  } else if (f1.name > f2.name) {
-    return 1;
-  } else {
-    return 0;
-  }
-});
-configurables[configurables.length - 1].next = false;
-
 function generate() {
-  fs.writeFileSync(`./src/Configurables.js`, mustache.render(template, {configurables: configurables}));
+  const configurables = globby.sync("./src/configurables/*.js").map(configurable => {
+    return {
+      name: configurable.split("/").pop().split(".js").shift(),
+      next: true
+    };
+  }).sort((f1, f2) => {
+    if (f1.name < f2.name) {
+      return -1;
+    } else if (f1.name > f2.name) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+  configurables[configurables.length - 1].next = false;
+
+  writer("./src/Configurables.js", mustache.render(template, {configurables: configurables}));
 }
 
 if (require.main === module) {

--- a/templates/Configurables.js
+++ b/templates/Configurables.js
@@ -2,11 +2,11 @@ const fs = require("fs");
 const globby = require("globby");
 const mustache = require("mustache");
 
-const template = `module.exports = {
-  {{ #configurables }}
-  {{{ name }}}: require("./configurables/{{{ name }}}"){{ #next }},{{ /next }}
-  {{ /configurables }}
-};
+const template = `module.exports = {\r
+  {{ #configurables }}\r
+  {{{ name }}}: require("./configurables/{{{ name }}}"){{ #next }},{{ /next }}\r
+  {{ /configurables }}\r
+};\r
 `;
 
 mustache.parse(template);

--- a/templates/Feature.js
+++ b/templates/Feature.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
 const globby = require("globby");
 const mustache = require("mustache");
+const writer = require("./CRLFWriter");
 
 const template = `const Feature = require("../../core/Feature");
 const {{{ section }}} = require("../../sections/{{{ section }}}");
@@ -54,7 +54,7 @@ const questions = [
 
 function generate() {
   const prompt = require("./prompt");
-  const generateFeatures = require("../templates/Features");
+  const generateFeatures = require("./Features");
 
   prompt(questions, answers => {
     const name = answers[0];
@@ -72,11 +72,7 @@ function generate() {
       enabled: enabled
     });
 
-    if (!fs.existsSync(`./src/features/${sectionLower}`)) {
-      fs.mkdirSync(`./src/features/${sectionLower}`);
-    }
-
-    fs.writeFileSync(`./src/features/${sectionLower}/${name}.js`, feature);
+    writer(`./src/features/${sectionLower}/${name}.js`, feature);
     generateFeatures();
   });
 }

--- a/templates/Features.js
+++ b/templates/Features.js
@@ -37,7 +37,7 @@ function generate() {
   });
   features[features.length - 1].next = false;
 
-  writer(`./src/Features.js`, mustache.render(template, {features: features}));
+  writer("./src/Features.js", mustache.render(template, {features: features}));
 }
 
 if (require.main === module) {

--- a/templates/Features.js
+++ b/templates/Features.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
 const globby = require("globby");
 const mustache = require("mustache");
+const writer = require("./CRLFWriter");
 
 const template = `module.exports = {
   {{ #features }}
@@ -37,7 +37,7 @@ function generate() {
   });
   features[features.length - 1].next = false;
 
-  fs.writeFileSync(`./src/Features.js`, mustache.render(template, {features: features}));
+  writer(`./src/Features.js`, mustache.render(template, {features: features}));
 }
 
 if (require.main === module) {

--- a/templates/Section.js
+++ b/templates/Section.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
 const globby = require("globby");
 const mustache = require("mustache");
+const writer = require("./CRLFWriter");
 
 const template = `const Section = require("../core/Section");
 
@@ -37,7 +37,7 @@ const questions = [
 
 function generate() {
   const prompt = require("./prompt");
-  const generateSections = require("../templates/Sections");
+  const generateSections = require("./Sections");
 
   prompt(questions, answers => {
     const name = answers[0];
@@ -48,7 +48,7 @@ function generate() {
       paths: paths
     });
 
-    fs.writeFileSync(`./src/sections/${name}.js`, section);
+    writer(`./src/sections/${name}.js`, section);
     generateSections();
   });
 }

--- a/templates/Sections.js
+++ b/templates/Sections.js
@@ -1,6 +1,6 @@
-const fs = require("fs");
 const globby = require("globby");
 const mustache = require("mustache");
+const writer = require("./CRLFWriter");
 
 const template = `module.exports = {
   {{ #sections }}
@@ -28,7 +28,7 @@ function generate() {
   });
   sections[sections.length - 1].next = false;
 
-  fs.writeFileSync(`./src/Sections.js`, mustache.render(template, {sections: sections}));
+  writer("./src/Sections.js", mustache.render(template, {sections: sections}));
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Changed how templates are rendered so that they are written using CRLF line endings.

Add .gitattributes to ensure JS files are checked in using CRLF line endings.

Closes #64.