### PR TITLE
tid/pid confusion

### DIFF
--- a/src/features/threads/LinkedAwards.js
+++ b/src/features/threads/LinkedAwards.js
@@ -33,7 +33,7 @@ class LinkedAwards extends Feature {
           result = matches[0];
         } else if (eggAwards.includes(award.classList.item(1))) {
           const postId = award.title.match(/\d+/g);
-          result = "https://hackforums.net/showthread.php?pid=" + postId + "#" + postId;
+          result = "https://hackforums.net/showthread.php?tid=" + postId;
         }
 
         if (result.length > 0) {

--- a/src/features/threads/LinkedAwards.js
+++ b/src/features/threads/LinkedAwards.js
@@ -32,8 +32,8 @@ class LinkedAwards extends Feature {
           const matches = award.title.match(urlRegex);
           result = matches[0];
         } else if (eggAwards.includes(award.classList.item(1))) {
-          const postId = award.title.match(/\d+/g);
-          result = "https://hackforums.net/showthread.php?tid=" + postId;
+          const threadId = award.title.match(/\d+/g);
+          result = "https://hackforums.net/showthread.php?tid=" + threadId;
         }
 
         if (result.length > 0) {


### PR DESCRIPTION
Fixing an old bug where clicking on HF Game eggs would redirect the members to pid=<id> instead of tid=<id> which would be the correct behavior.
Actually, from the context ("egg won from _post_ <id>") it seems like it's more like a HF issue, because it should show the post id the egg came from, not the thread id, but yeah... whatever I guess.